### PR TITLE
support for one-based indexes (automatic detection)

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -258,12 +258,13 @@ float *readMatrix(string inFilename, unsigned int &nRows, unsigned int &nColumns
 }
 
 void readSparseMatrixDimensions(string filename, unsigned int &nRows,
-                                unsigned int &nColumns) {
+                                unsigned int &nColumns, bool & zerobased) {
     ifstream file;
     file.open(filename.c_str());
     if (file.is_open()) {
         string line;
         int max_index = -1;
+        zerobased = false;
         while(getline(file, line)) {
             if (line.substr(0, 1) == "#") {
                 continue;
@@ -280,10 +281,15 @@ void readSparseMatrixDimensions(string filename, unsigned int &nRows,
                 if(dummy_index > max_index) {
                     max_index = dummy_index;
                 }
+                if (dummy_index == 0) {
+                    zerobased = true;
+                }
             }
             ++nRows;
         }
-        nColumns = max_index + 1;
+        nColumns = max_index;
+        if (zerobased)
+            ++nColumns;
         file.close();
     }
     else {
@@ -293,7 +299,8 @@ void readSparseMatrixDimensions(string filename, unsigned int &nRows,
 
 svm_node** readSparseMatrixChunk(string filename, unsigned int nRows,
                                  unsigned int nRowsToRead,
-                                 unsigned int rowOffset) {
+                                 unsigned int rowOffset,
+                                 unsigned int colOffset) {
     ifstream file;
     file.open(filename.c_str());
     string line;
@@ -336,7 +343,7 @@ svm_node** readSparseMatrixChunk(string filename, unsigned int nRows,
             if (linestream.fail())
                 break;
             //assert(sep==':');
-            x_matrix[i][j].index = idx;
+            x_matrix[i][j].index = idx-colOffset;
             x_matrix[i][j].value = val;
             j++;
         }

--- a/src/somoclu.cpp
+++ b/src/somoclu.cpp
@@ -343,12 +343,13 @@ int main(int argc, char** argv)
     float * dataRoot = NULL;
     unsigned int nDimensions = 0;
     unsigned int nVectors = 0;
+    bool zerobased;
     if(rank == 0 ) {
         if (kernelType == DENSE_CPU || kernelType == DENSE_GPU) {
             dataRoot = readMatrix(inFilename, nVectors, nDimensions);
         }
         else {
-            readSparseMatrixDimensions(inFilename, nVectors, nDimensions);
+            readSparseMatrixDimensions(inFilename, nVectors, nDimensions, zerobased);
         }
     }
 #ifdef HAVE_MPI
@@ -379,7 +380,8 @@ int main(int argc, char** argv)
         while (currentRankProcessed < nProcs) {
             if (rank == currentRankProcessed) {
                 sparseData = readSparseMatrixChunk(inFilename, nVectors, nVectorsPerRank,
-                                                   rank * nVectorsPerRank);
+                                                   rank * nVectorsPerRank,
+                                                   zerobased ? 0 : 1);
             }
             currentRankProcessed++;
 #ifdef HAVE_MPI

--- a/src/somoclu.h
+++ b/src/somoclu.h
@@ -66,10 +66,11 @@ int saveBmus(string filename, int *bmus, unsigned int nSomX,
 float *readMatrix(const string inFilename,
                   unsigned int &nRows, unsigned int &nCols);
 void readSparseMatrixDimensions(const string filename, unsigned int &nRows,
-                                unsigned int &nColumns);
+                                unsigned int &nColumns, bool& zerobased);
 svm_node** readSparseMatrixChunk(const string filename, unsigned int nRows,
                                  unsigned int nRowsToRead,
-                                 unsigned int rowOffset);
+                                 unsigned int rowOffset,
+                                 unsigned int colOffset=0);
 void trainOneEpoch(int itask, float *data, svm_node **sparseData,
                    float *codebook, int *globalBmus,
                    unsigned int nEpoch, unsigned int currentEpoch,


### PR DESCRIPTION
libsvm files often uses one-based indexes, so here is a patch to support this automatically (like `auto` mode with `sklearn.datasets.load_svmlight_file`).