### PR TITLE
Multiple cdist calls to counteract a memory error

### DIFF
--- a/src/Python/somoclu/train.py
+++ b/src/Python/somoclu/train.py
@@ -560,10 +560,13 @@ class Somoclu(object):
             d = self._data
         else:
             d = data
-        am = cdist(self.codebook.reshape((self.codebook.shape[0] *
-                                          self.codebook.shape[1],
-                                          self.codebook.shape[2])),
-                   d, 'euclidean').T
+        
+        codebookReshaped = self.codebook.reshape(self.codebook.shape[0] * self.codebook.shape[1], self.codebook.shape[2])
+        parts = np.array_split(d, 200, axis=0)
+        am = np.empty((0, (self._n_columns * self._n_rows)), dtype="float64")
+        for part in parts:
+            sum = np.concatenate((sum, (cdist((part), codebookReshaped, 'euclidean'))), axis=0)
+        
         if data is None:
             self.activation_map = am
         return am


### PR DESCRIPTION
To counteract the memory error mentioned in Issue #80 , several cdist calls have been created.
The input data here is divided into pieces à 200 rows, which is a rather random number which I found worked for me, although I think a formula could be developed to determine how small those parts need to be depending on the size of the input data, the dimension the map should have and the available RAM.