### PR TITLE
src/Makefile.in: fix compilation rule for libsomoclu so that make cor…

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -63,7 +63,9 @@ all: somoclu lib
 libwrapper: $(LIBOBJS)
 	$(CXX) -g $(DEFS) $(CXXFLAGS) $(CUDA_LDFLAGS) ${MPI_LIBDIR} -shared -o ${libname} $^ $(LIBS) $(CUDA_LIBS) ${MPI_LIBS}
 
-lib: $(LIBOBJS) io.o
+lib: ${libname}
+
+${libname}: $(LIBOBJS) io.o
 ifeq ($(OS), Windows_NT)
 	$(CXX) -g $(DEFS) $(CXXFLAGS) -shared -o ${libname} $^ $(LIBS)
 else


### PR DESCRIPTION
…rectly determines whether the rebuild on 'make lib' is necessary

Without this, every time I type 'make' or 'make lib', I get the libsomoclu.so library rebuilt regardless of whether any source changed. With this, it's rebuilt only if there was a modification in the associated sources.