### PR TITLE
Add norm-p as distance metric (with positive real p)

### DIFF
--- a/src/Python/doc/source/reference.rst
+++ b/src/Python/doc/source/reference.rst
@@ -2,7 +2,7 @@
 Function Reference
 ******************
 
-.. py:class:: Somoclu(n_columns, n_rows, initialcodebook=None, kerneltype=0, maptype='planar', gridtype='rectangular', compactsupport=False, neighborhood='gaussian', std_coeff=0.5, initialization=None)
+.. py:class:: Somoclu(n_columns, n_rows, initialcodebook=None, kerneltype=0, maptype='planar', gridtype='rectangular', compactsupport=False, neighborhood='gaussian', vect_distance='euclidean', std_coeff=0.5, initialization=None)
 
    Class for training and visualizing a self-organizing map.
 
@@ -40,6 +40,11 @@ Function Reference
 
                           * "gaussian": Gaussian neighborhood (default)
                           * "bubble": bubble neighborhood function
+   :param vect_distance: Optional parameter to specify the vector distance:
+
+                          * "euclidean": Euclidean distance (default)
+                          * "norm-inf": Infinity-norm distance (max among components)
+                          * "norm-p": p-norm (p-th root of summed differences raised to the power of p), works only if kerneltype is 0
    :type neighborhood: str.
    :param std_coeff: Optional parameter to set the coefficient in the Gaussian
                      neighborhood function exp(-||x-y||^2/(2*(coeff*radius)^2))

--- a/src/Python/somoclu/somoclu.i
+++ b/src/Python/somoclu/somoclu.i
@@ -37,4 +37,4 @@ void train(float *data, int data_length,
            float std_coeff, unsigned int verbose,
            float* codebook, int codebook_size,
            int* globalBmus, int globalBmus_size,
-           float* uMatrix, int uMatrix_size);
+           float* uMatrix, int uMatrix_size, string vect_distance);

--- a/src/R/R/Rsomoclu.R
+++ b/src/R/R/Rsomoclu.R
@@ -10,7 +10,7 @@ Rsomoclu.train <-
            scaleCooling,
            kernelType=0, mapType="planar", gridType="rectangular", 
            compactSupport=TRUE, neighborhood="gaussian", stdCoeff=0.5, 
-           codebook=NULL) {
+           codebook=NULL, vectDistance="euclidean") {
     if (is.null(codebook)) {
       codebook <- matrix(data = 0, nrow = nSomX * nSomY, ncol = dim(input_data)[2])
       codebook[1, 1] <- 1000
@@ -21,7 +21,7 @@ Rsomoclu.train <-
                  radiusCooling, scale0, scaleN,
                  scaleCooling, kernelType, mapType,
                  gridType, compactSupport, neighborhood, stdCoeff,
-                 codebook)
+                 codebook, vectDistance)
     res
   }
 

--- a/src/R/src/Rsomoclu.cpp
+++ b/src/R/src/Rsomoclu.cpp
@@ -17,7 +17,8 @@ RcppExport SEXP Rtrain(SEXP data_p,
                        SEXP gridType_p, SEXP compactSupport_p,
                        SEXP neighborhood_p,
                        SEXP stdCoeff_p,
-                       SEXP codebook_p) {
+                       SEXP codebook_p,
+                       SEXP vectDistance_p) {
     Rcpp::NumericMatrix dataMatrix(data_p);
     Rcpp::NumericMatrix codebookMatrix(codebook_p);
     int nVectors = dataMatrix.rows();
@@ -36,6 +37,7 @@ RcppExport SEXP Rtrain(SEXP data_p,
     bool compactSupport = as<bool>(compactSupport_p);
     string mapType = as<string>(mapType_p);
     string gridType = as<string>(gridType_p);
+    string vectDistance = as<string>(vectDistance_p);
     string neighborhood = as<string>(neighborhood_p);
     int data_length = nVectors * nDimensions;
     float* data = new float[data_length];
@@ -63,7 +65,7 @@ RcppExport SEXP Rtrain(SEXP data_p,
           gridType, compactSupport, neighborhood == "gaussian",
           std_coeff, 0,
           codebook, codebook_size, globalBmus, globalBmus_size,
-          uMatrix, uMatrix_size);
+          uMatrix, uMatrix_size, vectDistance);
     Rcpp::NumericMatrix globalBmusMatrix(nVectors, 2);
     Rcpp::NumericMatrix uMatrixMatrix(nSomX, nSomY);
     if(codebook != NULL) {

--- a/src/R/src/Rsomoclu_init.c
+++ b/src/R/src/Rsomoclu_init.c
@@ -8,10 +8,10 @@
 */
 
 /* .Call calls */
-extern SEXP Rtrain(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP Rtrain(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
-    {"Rtrain", (DL_FUNC) &Rtrain, 17},
+    {"Rtrain", (DL_FUNC) &Rtrain, 18},
     {NULL, NULL, 0}
 };
 

--- a/src/denseCpuKernels.cpp
+++ b/src/denseCpuKernels.cpp
@@ -34,6 +34,26 @@ float EuclideanDistance::operator()(float* vec1, float* vec2) const{
     return sqrt(distance);
 }
 
+float NormPDistance::operator()(float* vec1, float* vec2) const{
+    unsigned int nDimensions = Dim();
+    double distance = 0.0f;
+    for (unsigned int d = 0; d < nDimensions; ++d) {
+       distance += pow(fabs(vec1[d] - vec2[d]), p);
+    }
+    return pow(distance, 1.0/p);
+}
+
+float NormInfDistance::operator()(float* vec1, float* vec2) const{
+    unsigned int nDimensions = Dim();
+    double distance = 0.0f;
+    for (unsigned int d = 0; d < nDimensions; ++d) {
+       float tmp = fabs(vec1[d] - vec2[d]);
+       if (tmp > distance)
+          distance = tmp;
+    }
+    return distance;
+}
+
 /** Get node coords for the best matching unit (BMU)
  * @param coords - BMU coords
  * @param n - row num in the input feature file

--- a/src/somoclu.cpp
+++ b/src/somoclu.cpp
@@ -54,7 +54,7 @@ void printUsage() {
          "Arguments:\n" \
          "     -c FILENAME           Specify an initial map.codebook for the map.\n" \
          "     -d NUMBER             Coefficient in the Gaussian neighborhood function exp(-||x-y||^2/(2*(coeff*radius)^2)) (default: 0.5)\n" \
-         "     -D NORM               Norm to be used among vectors: euclidean, norm-inf or norm-p with any real p > 0\n" \
+         "     -D NORM               Norm to be used among vectors: euclidean, norm-inf or norm-p with any real p > 0 (default: euclidean)\n" \
          "     -e NUMBER             Maximum number of epochs (default: " << N_EPOCH << ")\n" \
          "     -g TYPE               Grid type: rectangular or hexagonal (default: rectangular)\n"\
          "     -h, --help            This help text\n" \
@@ -167,7 +167,7 @@ void processCommandLine(int argc, char** argv, string *inFilename,
         case 'D':
             *vect_distance = optarg;
             float p;
-            if (!(*vect_distance == "euclidean" || *vect_distance == "norm-inf" || (vect_distance->substr(0, 5) == "norm-" && sscanf(vect_distance->c_str() + 5, "%f", &p) == 1))) {
+            if (!(*vect_distance == "euclidean" || *vect_distance == "norm-inf" || (vect_distance->substr(0, 5) == "norm-" && sscanf(vect_distance->c_str() + 5, "%f", &p) == 1 && p > 0))) {
                 cli_abort("The argument of option -D should be either euclidean or norm-p (with p being a float > 0) or norm-inf.");
             }
             break;

--- a/src/somoclu.h
+++ b/src/somoclu.h
@@ -75,6 +75,22 @@ public:
     virtual float operator()(float* vec1, float* vec2) const;
 };
 
+class NormPDistance: public Distance{
+private:
+    float p;
+public:
+    NormPDistance(unsigned int d, float p):Distance(d), p(p){}
+    virtual ~NormPDistance(){}
+    virtual float operator()(float* vec1, float* vec2) const;
+};
+
+class NormInfDistance: public Distance{
+public:
+    NormInfDistance(unsigned int d):Distance(d){}
+    virtual ~NormInfDistance(){}
+    virtual float operator()(float* vec1, float* vec2) const;
+};
+
 /// Som parameters
 struct som {
     unsigned int nSomX;
@@ -130,7 +146,7 @@ void train(float *data, int data_length,
            float std_coeff, unsigned int verbose,
            float* codebook, int codebook_size,
            int* globalBmus, int globalBmus_size,
-           float* uMatrix, int uMatrix_size);
+           float* uMatrix, int uMatrix_size, string vect_distance = "euclidean");
 void train(int itask, float *data, svm_node **sparseData,
            som map, unsigned int nVectorsPerRank, unsigned int nEpoch,
            float radius0, float radiusN,

--- a/src/training.cpp
+++ b/src/training.cpp
@@ -20,6 +20,7 @@
 
 #include <cmath>
 #include <cstdlib>
+#include <cstring>
 #ifndef HAVE_MPI
 #include <stdexcept>
 #endif
@@ -89,7 +90,7 @@ void train(float *data, int data_length, unsigned int nEpoch,
            float std_coeff, unsigned int verbose,
            float *codebook, int codebook_size,
            int *globalBmus, int globalBmus_size,
-           float *uMatrix, int uMatrix_size) {
+           float *uMatrix, int uMatrix_size, string vect_distance) {
 #ifdef HAVE_R
 #ifndef CUDA
     if(kernelType == DENSE_GPU){
@@ -98,6 +99,16 @@ void train(float *data, int data_length, unsigned int nEpoch,
     }
 #endif // CUDA
 #endif // HAVE_R
+    Distance *d = 0;
+    float p;
+    if (vect_distance == "norm-inf")
+      d = new NormInfDistance(nDimensions);
+    else if (sscanf(vect_distance.c_str(), "norm-%f", &p) == 1 && p > 0)
+      d = new NormPDistance(nDimensions, p);
+    else if (vect_distance != "euclidean")
+      fprintf(stderr, "Warning: incorrect vect_distance: %s (falling back to euclidean)\n", vect_distance.c_str());
+    if (d == 0)
+      d = new EuclideanDistance(nDimensions);
     som map = {
         nSomX,
         nSomY,
@@ -105,7 +116,7 @@ void train(float *data, int data_length, unsigned int nEpoch,
         nVectors,
         mapType,
         gridType,
-		*(new EuclideanDistance(nDimensions)),
+        *d,
         uMatrix,
         codebook,
         globalBmus};


### PR DESCRIPTION
This patch adds the option to provide as vect_distance strings like "norm-3", "norm-6", "norm-2" (same as the default) and "norm-inf", besides "euclidean" when creating the SOM (norm-p with any positive real p). For example:
```
som = somoclu.Somoclu(n_columns, n_rows, compactsupport=False, vect_distance="norm-6")
```
This is supported with kerneltype = 0 only, at the moment (the GPU kernel uses an optimized implementation tied to p=2, but in the future it might be possible to add in denseGpuKernels.cu, alongside the current implementation, an alternate one if norm-p is specified).