### PR TITLE
Changed text to new MIT License

### DIFF
--- a/src/MATLAB/README.rst
+++ b/src/MATLAB/README.rst
@@ -6,7 +6,7 @@ URL: http://peterwittek.github.io/somoclu/
 
 BugReports: https://github.com/peterwittek/somoclu/issues
 
-License: GPL-3
+License: MIT
 
 OS_type: unix, windows
 

--- a/src/Python/doc/source/introduction.rst
+++ b/src/Python/doc/source/introduction.rst
@@ -19,9 +19,9 @@ Peter Wittek, Shi Chao Gao, Ik Soo Lim, Li Zhao (2017). Somoclu: An Efficient Pa
 
 Copyright and License
 ---------------------
-Somoclu is free software; you can redistribute it and/or modify it under the terms of the `GNU General Public License <http://www.gnu.org/licenses/gpl-3.0.html>`_ as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version.
+Somoclu is free software; you can redistribute it and/or modify it under the terms of the `MIT License <https://opensource.org/license/mit/>`_ as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version.
 
-Somoclu is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the `GNU General Public License <http://www.gnu.org/licenses/gpl-3.0.html>`_ for more details. 
+Somoclu is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the `MIT License <https://opensource.org/license/mit/>`_ for more details. 
 
 
 Acknowledgment

--- a/src/Python/setup.py
+++ b/src/Python/setup.py
@@ -148,7 +148,7 @@ else:
 try:
     setup(name='somoclu',
           version='1.7.6',
-          license='GPL3',
+          license='MIT',
           author="Peter Wittek, Shi Chao Gao",
           author_email="",
           maintainer="shichaogao",
@@ -160,7 +160,7 @@ try:
           packages=["somoclu"],
           install_requires=['numpy', 'matplotlib', 'scipy'],
           classifiers=[
-            'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+            'License :: OSI Approved :: MIT License',
             'Operating System :: OS Independent',
             'Development Status :: 5 - Production/Stable',
             'Topic :: Scientific/Engineering :: Artificial Intelligence',
@@ -176,7 +176,7 @@ except:
     traceback.print_exc()
     setup(name='somoclu',
           version='1.7.6',
-          license='GPL3',
+          license='MIT',
           author="Peter Wittek, Shi Chao Gao",
           author_email="",
           maintainer="shichaogao",
@@ -186,7 +186,7 @@ except:
           description="Massively parallel implementation of self-organizing maps",
           packages=["somoclu"],
           classifiers=[
-            'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+            'License :: OSI Approved :: MIT License',
             'Operating System :: OS Independent',
             'Development Status :: 5 - Production/Stable',
             'Topic :: Scientific/Engineering :: Artificial Intelligence',

--- a/src/R/DESCRIPTION
+++ b/src/R/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R: c(person(given = "Peter", family = "Wittek", role = c("aut"), email =
 Description: Somoclu is a massively parallel implementation of self-organizing maps.  It exploits multicore CPUs and it can be accelerated by CUDA. The topology of the map can be planar or toroid and the grid of neurons can be rectangular or hexagonal . Details refer to (Peter Wittek, et al (2017)) <doi:10.18637/jss.v078.i09>.
 URL: https://peterwittek.github.io/somoclu/
 BugReports: https://github.com/peterwittek/somoclu/issues
-License: GPL-3
+License: MIT
 Packaged: 2014-03-16 16:55:16 UTC;
 Author: Peter Wittek [aut], Shichao Gao [cre]
 Maintainer: Shichao Gao <xgdgsc@gmail.com>


### PR DESCRIPTION
Some readme and description files still had text in it which said that the package is distributed under the GPL license. 
Realized this when checking the pypi.org project page, which still states that this code is distributed as GPL code.